### PR TITLE
Added compatibility for Windows Phone 8.1 (WinPRT)

### DIFF
--- a/SharpLog/SharpLog.csproj
+++ b/SharpLog/SharpLog.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>SharpLog</RootNamespace>
     <AssemblyName>SharpLog</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
The current NuGet-Package isn't compatible with PCLs targeting Windows 8.1 Universal Apps. The code is 100% compatible, just the "Windows Phone 8.1" flag had to be added to the Project-Properties.

Would be great to see the NuGet-Package updated accordingly, too :-)

Signed-off-by: Gordon Breuer <gordon@outlook.de>